### PR TITLE
Added commands for installing ctags.

### DIFF
--- a/README
+++ b/README
@@ -13,6 +13,7 @@ Switch to the `~/.vim` directory, and fetch submodules:
     git submodule update
 
 NOTE:
-    for tags it's necessary to isntall ctags:
-        - yaourt -S ctags
-        - debian ?
+    for tags it's necessary to install ctags:
+        - arch linux: yaourt -S ctags
+        - debian: apt-get install exuberant-ctags
+		- redhat: yum install ctags


### PR DESCRIPTION
Added commands specifying the packages that are needed for installing ctags in debian-like and redhat-like distributions.

I was looking for this myself and I stumbled across your repository.  It would be good documentation for anyone else who ends up here.
